### PR TITLE
Fixed namespace error

### DIFF
--- a/back/logging/LogWriter.php
+++ b/back/logging/LogWriter.php
@@ -40,7 +40,7 @@ class LogWriter {
 		//Check permissions of file.
 		if(!is_writable($log_file)){
 			//throw exception if not writable
-			throw new Exception("ERROR: Unable to write to file!", 1);
+			throw new \Exception("ERROR: Unable to write to file!", 1);
 		}
 	}
 	/**

--- a/front/logging/LogWriter.php
+++ b/front/logging/LogWriter.php
@@ -37,7 +37,7 @@ class LogWriter {
 		//Check permissions of file.
 		if(!is_writable($log_file)){
 			//throw exception if not writable
-			throw new Exception("ERROR: Unable to write to file!", 1);
+			throw new \Exception("ERROR: Unable to write to file!", 1);
 		}
 	}
 	/**


### PR DESCRIPTION
`Exception` needed a backslash because it does not exist in the declared namespace. Without the backslash, PHP looks for the `Exception` class in the declared namespace.